### PR TITLE
feat(gcp-iam-policy-members): add Helm chart for managing GCP IAM policy members with initial configuration and templates

### DIFF
--- a/charts/gcp-iam-policy-memebers/.helmignore
+++ b/charts/gcp-iam-policy-memebers/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/gcp-iam-policy-memebers/Chart.yaml
+++ b/charts/gcp-iam-policy-memebers/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: gcp-iam-policy-memebers
+description: A Helm chart that Creates GCP IAM Policy Memebers through Config Connector
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+maintainers:
+  - name: ilyasabdellaoui
+    email: ilyas.abdellaoui21@gmail.com
+    url: https://github.com/ilyasabdellaoui
+  - name: wiemaouadi
+    email: wiem.aouadi3@gmail.com
+    url: https://github.com/wiemaouadi

--- a/charts/gcp-iam-policy-memebers/README.md
+++ b/charts/gcp-iam-policy-memebers/README.md
@@ -22,21 +22,10 @@ A Helm chart that Creates GCP IAM Policy Memebers through Config Connector
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| condition | object | `{"description":"","expression":null,"title":null}` | Immutable. Optional. The condition under which the binding applies. |
 | global.abandon | bool | `false` | Keep the resource even after the kcc resource deletion. |
 | global.cnrmNamespace | string | `nil` | Allows to deploy in another namespace than the release one |
 | global.gcpProjectId | string | `"myprojectid"` | Google Project ID |
-| member | string | `"serviceAccount:iampolicymember@${PROJECT_ID}.iam.gserviceaccount.com"` | Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used. |
-| memberFrom | object | `{"bigQueryConnectionConnectionRef":{"name":null,"namespace":null,"type":null},"logSinkRef":{"name":null,"namespace":null},"serviceAccountRef":{"name":null,"namespace":null},"serviceIdentityRef":{"name":null,"namespace":null},"sqlInstanceRef":{"name":null,"namespace":null}}` | Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used, and only one subfield within 'memberFrom' can be used. |
-| memberFrom.bigQueryConnectionConnectionRef | object | `{"name":null,"namespace":null,"type":null}` | BigQueryConnectionConnection whose service account is to be bound to the role. Use the Type field to specifie the connection type. For "spark" connetion, the service account is in `status.observedState.spark.serviceAccountID`. For "cloudSQL" connection, the service account is in `status.observedState.cloudSQL.serviceAccountID`. For "cloudResource" connection, the service account is in `status.observedState.cloudResource.serviceAccountID`. |
-| memberFrom.bigQueryConnectionConnectionRef.type | string | `nil` | Type field specifies the connection type of the BigQueryConnectionConnection resource, whose service account is to be bound to the role. |
-| memberFrom.logSinkRef | object | `{"name":null,"namespace":null}` | The LoggingLogSink whose writer identity (i.e. its 'status.writerIdentity') is to be bound to the role. |
-| memberFrom.serviceAccountRef | object | `{"name":null,"namespace":null}` | The IAMServiceAccount to be bound to the role. |
-| memberFrom.serviceIdentityRef | object | `{"name":null,"namespace":null}` | The ServiceIdentity whose service account (i.e., its 'status.email') is to be bound to the role. |
-| memberFrom.sqlInstanceRef | object | `{"name":null,"namespace":null}` | The SQLInstance whose service account (i.e. its 'status.serviceAccountEmailAddress') is to be bound to the role. |
-| name | string | `"ekp-iam-policy-member"` | Name of the IAM Policy Member. |
-| resourceRef | object | `{"apiVersion":null,"external":"projects/${PROJECT_ID}","kind":"Project","name":null,"namespace":null}` | Immutable. Required. The GCP resource to set the IAM policy on. |
-| role | string | `"roles/editor"` | Immutable. Required. The role for which the Member will be bound. |
+| iamPolicyMembers | list | `[]` |  |
 
 ## Installing the Chart
 

--- a/charts/gcp-iam-policy-memebers/README.md
+++ b/charts/gcp-iam-policy-memebers/README.md
@@ -59,7 +59,6 @@ spec:
     helm:
 
       values: |
-        name: mysa
 
   destination:
     server: https://kubernetes.default.svc

--- a/charts/gcp-iam-policy-memebers/README.md.gotmpl
+++ b/charts/gcp-iam-policy-memebers/README.md.gotmpl
@@ -1,0 +1,94 @@
+# {{ .Name }}
+
+{{ template "chart.versionBadge" .}}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## Prerequisites
+
+- Helm v{{ if eq .ApiVersion "v2" }}3{{ else }}2{{end}}
+- Config Connector installed (v1.6.0)
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+## Description
+
+{{ template "chart.description" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+## Installing the Chart
+
+### With Helm
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add ekp-helm https://edixos.github.io/ekp-helm
+helm install ekp-helm/{{ .Name }}
+```
+
+### With ArgoCD
+
+Add new application as:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Name }}
+spec:
+  project: infra
+
+  source:
+    repoURL: "https://edixos.github.io/ekp-helm"
+    targetRevision: "{{ .Version }}"
+    chart: {{ .Name }}
+    path: ''
+
+    helm:
+
+      values: |
+        name: mysa
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: "cnrm-system"
+  syncPolicy:
+    automated:
+      prune: true
+```
+
+## Develop
+
+### Update documentation
+
+Chart documentation is generated with [helm-docs](https://github.com/norwoodj/helm-docs) from `values.yaml` file.
+After file modification, regenerate README.md with command:
+
+```bash
+docker run --rm -it -v $(pwd):/helm --workdir /helm jnorwood/helm-docs:v1.14.2 helm-docs
+```
+
+### Run linter
+
+```bash
+docker run --rm -it -w /charts -v $(pwd)/../../:/charts quay.io/helmpack/chart-testing:v3.12.0 ct lint --charts /charts/charts/{{ .Name }} --config /charts/charts/{{ .Name }}/ct.yaml
+```
+
+### Run pluto
+
+In order to check if the api-version used in this chart are not deprecated, or worse, removed, we use pluto to check it:
+
+```
+docker run --rm -it -v $(pwd):/apps -v pluto:/pluto alpine/helm:3.17 template {{ .Name }} . -f tests/pluto/values.yaml --output-dir /pluto
+docker run --rm -it -v pluto:/data us-docker.pkg.dev/fairwinds-ops/oss/pluto:v5 detect-files -d /data -o yaml --ignore-deprecations -t "k8s=v1.31.0,cert-manager=v1.17.0,istio=v1.24.0" -o wide
+docker volume rm pluto
+```
+

--- a/charts/gcp-iam-policy-memebers/README.md.gotmpl
+++ b/charts/gcp-iam-policy-memebers/README.md.gotmpl
@@ -55,7 +55,6 @@ spec:
     helm:
 
       values: |
-        name: mysa
 
   destination:
     server: https://kubernetes.default.svc

--- a/charts/gcp-iam-policy-memebers/ct.yaml
+++ b/charts/gcp-iam-policy-memebers/ct.yaml
@@ -1,0 +1,6 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - charts
+helm-extra-args: --timeout=500
+check-version-increment: true

--- a/charts/gcp-iam-policy-memebers/templates/_helpers.tpl
+++ b/charts/gcp-iam-policy-memebers/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "gcp-iam-policy-memebers.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "gcp-iam-policy-memebers.fullname" -}}
+{{- if .Values.name }}
+{{- .Values.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gcp-iam-policy-memebers.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "gcp-iam-policy-memebers.labels" -}}
+helm.sh/chart: {{ include "gcp-iam-policy-memebers.chart" . }}
+{{ include "gcp-iam-policy-memebers.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gcp-iam-policy-memebers.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gcp-iam-policy-memebers.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "gcp-iam-policy-memebers.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "gcp-iam-policy-memebers.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define Namespace
+*/}}
+{{- define "gcp-iam-policy-memebers.namespace" -}}
+{{ default .Release.Namespace .Values.global.cnrmNamespace }}
+{{- end -}}

--- a/charts/gcp-iam-policy-memebers/templates/iam-policy-memebrs.yaml
+++ b/charts/gcp-iam-policy-memebers/templates/iam-policy-memebrs.yaml
@@ -25,6 +25,7 @@ spec:
   {{- fail "Error: role is required" }}
   {{- end }}
 
+  memberFrom:
 {{- if .memberFrom }}
   {{- if .memberFrom.bigQueryConnectionConnectionRef }}
     {{- if and .memberFrom.bigQueryConnectionConnectionRef.name .memberFrom.bigQueryConnectionConnectionRef.type }}

--- a/charts/gcp-iam-policy-memebers/templates/iam-policy-memebrs.yaml
+++ b/charts/gcp-iam-policy-memebers/templates/iam-policy-memebrs.yaml
@@ -1,0 +1,86 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  annotations:
+{{- if .Values.global.abandon }}
+    cnrm.cloud.google.com/deletion-policy: abandon
+{{- end }}
+    cnrm.cloud.google.com/project-id: {{ .Values.global.gcpProjectId | quote }}
+  labels:
+{{- include "gcp-iam-policy-memebers.labels" . | nindent 4 }}
+  name: {{ include "gcp-iam-policy-memebers.fullname" . }}
+  namespace: {{ include "gcp-iam-policy-memebers.namespace" . }}
+spec:
+  {{- if .Values.condition }}
+  {{- if and .Values.condition.title .Values.condition.expression }}
+  condition:
+    title: {{ .Values.condition.title }}
+    expression: {{ .Values.condition.expression }}
+    description: {{ .Values.condition.description }}
+  {{- end }}
+  {{- end }}
+  member: {{ .Values.member }}
+
+  {{- if .Values.role }}
+  role: {{ .Values.role }}
+  {{- else }}
+  {{- fail "Error: role is required" }}
+  {{- end }}
+
+  memberFrom:
+  {{- if .Values.memberFrom.bigQueryConnectionConnectionRef }}
+  {{- if and .Values.memberFrom.bigQueryConnectionConnectionRef.name .Values.memberFrom.bigQueryConnectionConnectionRef.type}}
+    bigQueryConnectionConnectionRef:
+      name: {{ .Values.memberFrom.bigQueryConnectionConnectionRef.name }}
+      type: {{ .Values.memberFrom.bigQueryConnectionConnectionRef.type }}
+      namespace: {{ .Values.memberFrom.bigQueryConnectionConnectionRef.namespace }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.memberFrom.logSinkRef }}
+  {{- if .Values.memberFrom.logSinkRef.name }}
+    logSinkRef:
+      name: {{ .Values.memberFrom.logSinkRef.name }}
+      namespace: {{ .Values.memberFrom.logSinkRef.namespace }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.memberFrom.serviceAccountRef }}
+  {{- if .Values.memberFrom.serviceAccountRef.name }}
+    serviceAccountRef:
+      name: {{ .Values.memberFrom.serviceAccountRef.name }}
+      namespace: {{ .Values.memberFrom.serviceAccountRef.namespace }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.memberFrom.serviceIdentityRef }}
+  {{- if .Values.memberFrom.serviceIdentityRef.name }}
+    serviceIdentityRef:
+      name: {{ .Values.memberFrom.serviceIdentityRef.name }}
+      namespace: {{ .Values.memberFrom.serviceIdentityRef.namespace }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.memberFrom.sqlInstanceRef }}
+  {{- if .Values.memberFrom.sqlInstanceRef.name }}
+    sqlInstanceRef:
+      name: {{ .Values.memberFrom.sqlInstanceRef.name }}
+      namespace: {{ .Values.memberFrom.sqlInstanceRef.namespace }}
+  {{- end }}
+  {{- end }}
+
+  {{- if .Values.resourceRef }}
+  {{- if and .Values.resourceRef.kind }}
+  resourceRef:
+    kind: {{ .Values.resourceRef.kind }}
+    {{- if .Values.resourceRef.external }}
+    external: {{ .Values.resourceRef.external }}
+    {{- else if .Values.resourceRef.name }}
+    name: {{ .Values.resourceRef.name }}
+    {{- end }}
+    {{- if .Values.resourceRef.apiVersion }}
+    apiVersion: {{ .Values.resourceRef.apiVersion }}
+    {{- end }}
+    namespace: {{ .Values.resourceRef.namespace }}
+  {{- else }}
+  {{- fail "resourceRef.kind is required" }}
+  {{- end }}
+  {{- else }}
+  {{- fail "Error: resourceRef is required" }}
+  {{- end }}

--- a/charts/gcp-iam-policy-memebers/templates/iam-policy-memebrs.yaml
+++ b/charts/gcp-iam-policy-memebers/templates/iam-policy-memebrs.yaml
@@ -1,86 +1,91 @@
+{{- range .Values.iamPolicyMembers }}
+---
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
   annotations:
-{{- if .Values.global.abandon }}
-    cnrm.cloud.google.com/deletion-policy: abandon
-{{- end }}
-    cnrm.cloud.google.com/project-id: {{ .Values.global.gcpProjectId | quote }}
-  labels:
-{{- include "gcp-iam-policy-memebers.labels" . | nindent 4 }}
-  name: {{ include "gcp-iam-policy-memebers.fullname" . }}
-  namespace: {{ include "gcp-iam-policy-memebers.namespace" . }}
-spec:
-  {{- if .Values.condition }}
-  {{- if and .Values.condition.title .Values.condition.expression }}
-  condition:
-    title: {{ .Values.condition.title }}
-    expression: {{ .Values.condition.expression }}
-    description: {{ .Values.condition.description }}
-  {{- end }}
-  {{- end }}
-  member: {{ .Values.member }}
+    cnrm.cloud.google.com/project-id: {{ $.Values.global.gcpProjectId }}
+  name: {{ .name }}
 
-  {{- if .Values.role }}
-  role: {{ .Values.role }}
+spec:
+  {{- if .condition }}
+  {{- if and .condition.title .condition.expression }}
+  condition:
+    title: {{ .condition.title }}
+    expression: {{ .condition.expression }}
+    description: {{ .condition.description }}
+  {{- end }}
+  {{- end }}
+
+  member: {{ .member }}
+
+  {{- if .role }}
+  role: {{ .role }}
   {{- else }}
   {{- fail "Error: role is required" }}
   {{- end }}
 
-  memberFrom:
-  {{- if .Values.memberFrom.bigQueryConnectionConnectionRef }}
-  {{- if and .Values.memberFrom.bigQueryConnectionConnectionRef.name .Values.memberFrom.bigQueryConnectionConnectionRef.type}}
-    bigQueryConnectionConnectionRef:
-      name: {{ .Values.memberFrom.bigQueryConnectionConnectionRef.name }}
-      type: {{ .Values.memberFrom.bigQueryConnectionConnectionRef.type }}
-      namespace: {{ .Values.memberFrom.bigQueryConnectionConnectionRef.namespace }}
+{{- if .memberFrom }}
+  {{- if .memberFrom.bigQueryConnectionConnectionRef }}
+    {{- if and .memberFrom.bigQueryConnectionConnectionRef.name .memberFrom.bigQueryConnectionConnectionRef.type }}
+      bigQueryConnectionConnectionRef:
+        name: {{ .memberFrom.bigQueryConnectionConnectionRef.name }}
+        type: {{ .memberFrom.bigQueryConnectionConnectionRef.type }}
+        namespace: {{ .memberFrom.bigQueryConnectionConnectionRef.namespace }}
+    {{- end }}
   {{- end }}
-  {{- end }}
-  {{- if .Values.memberFrom.logSinkRef }}
-  {{- if .Values.memberFrom.logSinkRef.name }}
+
+
+
+  {{- if .memberFrom.logSinkRef }}
+  {{- if .memberFrom.logSinkRef.name }}
     logSinkRef:
-      name: {{ .Values.memberFrom.logSinkRef.name }}
-      namespace: {{ .Values.memberFrom.logSinkRef.namespace }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.memberFrom.serviceAccountRef }}
-  {{- if .Values.memberFrom.serviceAccountRef.name }}
-    serviceAccountRef:
-      name: {{ .Values.memberFrom.serviceAccountRef.name }}
-      namespace: {{ .Values.memberFrom.serviceAccountRef.namespace }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.memberFrom.serviceIdentityRef }}
-  {{- if .Values.memberFrom.serviceIdentityRef.name }}
-    serviceIdentityRef:
-      name: {{ .Values.memberFrom.serviceIdentityRef.name }}
-      namespace: {{ .Values.memberFrom.serviceIdentityRef.namespace }}
-  {{- end }}
-  {{- end }}
-  {{- if .Values.memberFrom.sqlInstanceRef }}
-  {{- if .Values.memberFrom.sqlInstanceRef.name }}
-    sqlInstanceRef:
-      name: {{ .Values.memberFrom.sqlInstanceRef.name }}
-      namespace: {{ .Values.memberFrom.sqlInstanceRef.namespace }}
+      name: {{ .memberFrom.logSinkRef.name }}
+      namespace: {{ .memberFrom.logSinkRef.namespace }}
   {{- end }}
   {{- end }}
 
-  {{- if .Values.resourceRef }}
-  {{- if and .Values.resourceRef.kind }}
+  {{- if .memberFrom.serviceAccountRef }}
+  {{- if .memberFrom.serviceAccountRef.name }}
+    serviceAccountRef:
+      name: {{ .memberFrom.serviceAccountRef.name }}
+      namespace: {{ .memberFrom.serviceAccountRef.namespace }}
+  {{- end }}
+  {{- end }}
+
+  {{- if .memberFrom.serviceIdentityRef }}
+  {{- if .memberFrom.serviceIdentityRef.name }}
+    serviceIdentityRef:
+      name: {{ .memberFrom.serviceIdentityRef.name }}
+      namespace: {{ .memberFrom.serviceIdentityRef.namespace }}
+  {{- end }}
+  {{- end }}
+
+  {{- if .memberFrom.sqlInstanceRef }}
+  {{- if .memberFrom.sqlInstanceRef.name }}
+    sqlInstanceRef:
+      name: {{ .memberFrom.sqlInstanceRef.name }}
+      namespace: {{ .memberFrom.sqlInstanceRef.namespace }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+  {{- if .resourceRef }}
+  {{- if and .resourceRef.kind }}
   resourceRef:
-    kind: {{ .Values.resourceRef.kind }}
-    {{- if .Values.resourceRef.external }}
-    external: {{ .Values.resourceRef.external }}
-    {{- else if .Values.resourceRef.name }}
-    name: {{ .Values.resourceRef.name }}
+    kind: {{ .resourceRef.kind }}
+    {{- if .resourceRef.external }}
+    external: {{ .resourceRef.external }}
+    {{- else if .resourceRef.name }}
+    name: {{ .resourceRef.name }}
     {{- end }}
-    {{- if .Values.resourceRef.apiVersion }}
-    apiVersion: {{ .Values.resourceRef.apiVersion }}
+    {{- if .resourceRef.apiVersion }}
+    apiVersion: {{ .resourceRef.apiVersion }}
     {{- end }}
-    namespace: {{ .Values.resourceRef.namespace }}
+    namespace: {{ .resourceRef.namespace }}
   {{- else }}
   {{- fail "resourceRef.kind is required" }}
   {{- end }}
   {{- else }}
   {{- fail "Error: resourceRef is required" }}
   {{- end }}
+{{- end }}

--- a/charts/gcp-iam-policy-memebers/tests/pluto/values.yaml
+++ b/charts/gcp-iam-policy-memebers/tests/pluto/values.yaml
@@ -1,11 +1,17 @@
 global:
-  gcpProjectId: ekp-dev
+  gcpProjectId: "ekp-dev"
 
-name: "ekp-iam-policy-member"
+iamPolicyMembers:
+  - name: "member-1"
+    member: "serviceAccount:ekp-infra-sa@ekp-dev.iam.gserviceaccount.com"
+    role: "roles/editor"
+    resourceRef:
+      kind: "Project"
+      external: "projects/ekp-dev"
 
-member: serviceAccount:ekp-infra-sa@ekp-dev.iam.gserviceaccount.com
-role: "roles/bigquery.dataViewer"
-
-resourceRef:
-    kind: "Project"
-    external: "projects/ekp-dev"
+  - name: "member-2"
+    member: "serviceAccount:ekp-infra-sa@ekp-dev.iam.gserviceaccount.com"
+    role: "roles/viewer"
+    resourceRef:
+      kind: "Project"
+      external: "projects/ekp-dev"

--- a/charts/gcp-iam-policy-memebers/tests/pluto/values.yaml
+++ b/charts/gcp-iam-policy-memebers/tests/pluto/values.yaml
@@ -1,0 +1,11 @@
+global:
+  gcpProjectId: ekp-dev
+
+name: "ekp-iam-policy-member"
+
+member: serviceAccount:ekp-infra-sa@ekp-dev.iam.gserviceaccount.com
+role: "roles/bigquery.dataViewer"
+
+resourceRef:
+    kind: "Project"
+    external: "projects/ekp-dev"

--- a/charts/gcp-iam-policy-memebers/values.yaml
+++ b/charts/gcp-iam-policy-memebers/values.yaml
@@ -20,7 +20,7 @@ member: serviceAccount:iampolicymember@${PROJECT_ID}.iam.gserviceaccount.com
 # -- Immutable. Required. The role for which the Member will be bound.
 role: "roles/editor"
 # -- Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used, and only one subfield within 'memberFrom' can be used.
-memberFrom: 
+memberFrom:
   # -- BigQueryConnectionConnection whose service account is to be bound to the role. Use the Type field to specifie the connection type. For "spark" connetion, the service account is in `status.observedState.spark.serviceAccountID`. For "cloudSQL" connection, the service account is in `status.observedState.cloudSQL.serviceAccountID`. For "cloudResource" connection, the service account is in `status.observedState.cloudResource.serviceAccountID`.
   bigQueryConnectionConnectionRef:
     name:

--- a/charts/gcp-iam-policy-memebers/values.yaml
+++ b/charts/gcp-iam-policy-memebers/values.yaml
@@ -6,48 +6,4 @@ global:
   gcpProjectId: myprojectid
   # -- Keep the resource even after the kcc resource deletion.
   abandon: false
-
-# -- Name of the IAM Policy Member.
-name: "ekp-iam-policy-member"
-# -- Immutable. Optional. The condition under which the binding applies.
-condition:
-  title:
-  expression:
-  description: ""
-
-# -- Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used.
-member: serviceAccount:iampolicymember@${PROJECT_ID}.iam.gserviceaccount.com
-# -- Immutable. Required. The role for which the Member will be bound.
-role: "roles/editor"
-# -- Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used, and only one subfield within 'memberFrom' can be used.
-memberFrom:
-  # -- BigQueryConnectionConnection whose service account is to be bound to the role. Use the Type field to specifie the connection type. For "spark" connetion, the service account is in `status.observedState.spark.serviceAccountID`. For "cloudSQL" connection, the service account is in `status.observedState.cloudSQL.serviceAccountID`. For "cloudResource" connection, the service account is in `status.observedState.cloudResource.serviceAccountID`.
-  bigQueryConnectionConnectionRef:
-    name:
-    namespace:
-    # -- Type field specifies the connection type of the BigQueryConnectionConnection resource, whose service account is to be bound to the role.
-    type:
-  # -- The LoggingLogSink whose writer identity (i.e. its 'status.writerIdentity') is to be bound to the role.
-  logSinkRef:
-    name:
-    namespace:
-  # -- The IAMServiceAccount to be bound to the role.
-  serviceAccountRef:
-    name:
-    namespace:
-  # -- The ServiceIdentity whose service account (i.e., its 'status.email') is to be bound to the role.
-  serviceIdentityRef:
-    name:
-    namespace:
-  # -- The SQLInstance whose service account (i.e. its 'status.serviceAccountEmailAddress') is to be bound to the role.
-  sqlInstanceRef:
-    name:
-    namespace:
-
-# -- Immutable. Required. The GCP resource to set the IAM policy on.
-resourceRef:
-  kind: Project
-  external: projects/${PROJECT_ID}
-  apiVersion:
-  name:
-  namespace:
+iamPolicyMembers: []

--- a/charts/gcp-iam-policy-memebers/values.yaml
+++ b/charts/gcp-iam-policy-memebers/values.yaml
@@ -1,0 +1,53 @@
+global:
+  # -- Allows to deploy in another namespace than the release one
+  # @default -- `nil`
+  cnrmNamespace: ""
+  # -- Google Project ID
+  gcpProjectId: myprojectid
+  # -- Keep the resource even after the kcc resource deletion.
+  abandon: false
+
+# -- Name of the IAM Policy Member.
+name: "ekp-iam-policy-member"
+# -- Immutable. Optional. The condition under which the binding applies.
+condition:
+  title:
+  expression:
+  description: ""
+
+# -- Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used.
+member: serviceAccount:iampolicymember@${PROJECT_ID}.iam.gserviceaccount.com
+# -- Immutable. Required. The role for which the Member will be bound.
+role: "roles/editor"
+# -- Immutable. The IAM identity to be bound to the role. Exactly one of 'member' or 'memberFrom' must be used, and only one subfield within 'memberFrom' can be used.
+memberFrom: 
+  # -- BigQueryConnectionConnection whose service account is to be bound to the role. Use the Type field to specifie the connection type. For "spark" connetion, the service account is in `status.observedState.spark.serviceAccountID`. For "cloudSQL" connection, the service account is in `status.observedState.cloudSQL.serviceAccountID`. For "cloudResource" connection, the service account is in `status.observedState.cloudResource.serviceAccountID`.
+  bigQueryConnectionConnectionRef:
+    name:
+    namespace:
+    # -- Type field specifies the connection type of the BigQueryConnectionConnection resource, whose service account is to be bound to the role.
+    type:
+  # -- The LoggingLogSink whose writer identity (i.e. its 'status.writerIdentity') is to be bound to the role.
+  logSinkRef:
+    name:
+    namespace:
+  # -- The IAMServiceAccount to be bound to the role.
+  serviceAccountRef:
+    name:
+    namespace:
+  # -- The ServiceIdentity whose service account (i.e., its 'status.email') is to be bound to the role.
+  serviceIdentityRef:
+    name:
+    namespace:
+  # -- The SQLInstance whose service account (i.e. its 'status.serviceAccountEmailAddress') is to be bound to the role.
+  sqlInstanceRef:
+    name:
+    namespace:
+
+# -- Immutable. Required. The GCP resource to set the IAM policy on.
+resourceRef:
+  kind: Project
+  external: projects/${PROJECT_ID}
+  apiVersion:
+  name:
+  namespace:


### PR DESCRIPTION
Closes #3 