### PR TITLE
Fix lint

### DIFF
--- a/scripts/fix-lint.sh
+++ b/scripts/fix-lint.sh
@@ -31,6 +31,9 @@ process_file() {
     if [ "$FIX_COMMENTS" = "yes" ]; then
         # Fix comment spacing on non-comment lines only
         $SED -i '/^[ \t]*#/!s/\([^ \t]\)[ \t]*#/\1  #/g' "$file"
+        
+        # Fix missing space after # for both full-line and inline comments (e.g. #- -> # -)
+        $SED -i 's/\(^[ \t]*#\|[ \t][ \t]*#\)\([^ \t#!]\)/\1 \2/g' "$file"
     fi
     
     # Ensure file ends with a newline


### PR DESCRIPTION
Closes #202 

**Root cause:** the dependency updater merged upstream Cilium defaults that contain comments missing a space after `#` (e.g. `#- PERFMON`). Our `yamllint` config requires a space after `#`, so `ct lint` failed during the automated bump.

**Action taken:** Updated `scripts/fix-lint.sh` to safely normalize comment spacing (inserting a space after `#` for both full-line and inline comments) before running lint checks + Verified `ct lint` passes for the cilium chart locally after this fix.